### PR TITLE
fix libfsapfs_key_encrypted_key hmac size

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -68,11 +68,13 @@ environment:
     CONFIGURE_OPTIONS: "--enable-python2"
     CFLAGS: "--coverage"
     LDFLAGS: "--coverage"
+    PYTHON_VERSION: 2
   - TARGET: cygwin-gcc-python3
     BUILD_ENVIRONMENT: cygwin
     CONFIGURE_OPTIONS: "--enable-python3"
     CFLAGS: "--coverage"
     LDFLAGS: "--coverage"
+    PYTHON_VERSION: 3
   - TARGET: cygwin-gcc-static-executables
     BUILD_ENVIRONMENT: cygwin
     CONFIGURE_OPTIONS: "--enable-static-executables"
@@ -99,11 +101,13 @@ environment:
     CONFIGURE_OPTIONS: "--enable-python2"
     CFLAGS: "--coverage"
     LDFLAGS: "--coverage"
+    PYTHON_VERSION: 2
   - TARGET: cygwin64-gcc-python3
     BUILD_ENVIRONMENT: cygwin64
     CONFIGURE_OPTIONS: "--enable-python3"
     CFLAGS: "--coverage"
     LDFLAGS: "--coverage"
+    PYTHON_VERSION: 3
   - TARGET: cygwin64-gcc-static-executables
     BUILD_ENVIRONMENT: cygwin64
     CONFIGURE_OPTIONS: "--enable-static-executables"

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ AC_PREREQ( 2.59 )
 
 AC_INIT(
  [libfsapfs],
- [20190210],
+ [20190223],
  [joachim.metz@gmail.com])
 
 AC_CONFIG_SRCDIR(

--- a/libfsapfs/libfsapfs_key_encrypted_key.h
+++ b/libfsapfs/libfsapfs_key_encrypted_key.h
@@ -41,7 +41,7 @@ struct libfsapfs_key_encrypted_key
 
 	/* The HMAC
 	 */
-	uint8_t hmac[ 23 ];
+	uint8_t hmac[ 32 ];
 
 	/* The number of iterations
 	 */


### PR DESCRIPTION
https://github.com/libyal/libfsapfs/blob/a58c2f25ac2f73faf1ce29a627bbd9294ab50406/libfsapfs/libfsapfs_key_encrypted_key.c#L387
this memory copy will effect number_of_iterations while hmac has wrong size