### PR TITLE
Fix the bug when checkpoint area offset is larger than 4GB

### DIFF
--- a/libfsapfs/libfsapfs_container.c
+++ b/libfsapfs/libfsapfs_container.c
@@ -1204,7 +1204,7 @@ int libfsapfs_internal_container_open_read(
 
 		goto on_error;
 	}
-	file_offset = internal_container->superblock->checkpoint_descriptor_area_block_number * internal_container->io_handle->block_size;
+	file_offset = (uint64_t)internal_container->superblock->checkpoint_descriptor_area_block_number * internal_container->io_handle->block_size;
 
 	for( metadata_block_index = 0;
 	     metadata_block_index <= internal_container->superblock->checkpoint_descriptor_area_number_of_blocks;


### PR DESCRIPTION
When testing libfsapfs with one of my larger SSDs (1TB), I noticed that checkpoint descriptor area offset calculation is still `uint32_t * uint32_t` which results in an incorrect truncated 32bit offset. So here's the fix :)