### PR TITLE
Update autogen.sh to support Homebrew-installed autotools.

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -23,6 +23,11 @@ then
 fi
 if ! test -x "${BINDIR}/aclocal";
 then
+	# Default location of Homebrew installed binaries.
+	BINDIR="/opt/homebrew/bin";
+fi
+if ! test -x "${BINDIR}/aclocal";
+then
 	# Default location of 32-bit MSYS2-MinGW installed binaries.
 	BINDIR="/mingw32/bin";
 fi


### PR DESCRIPTION
If autotools build dependencies were installed with recent Homebrew, the current autogen.sh script won't find them.  The solution is to add `/opt/homebrew/bin` to the list of search paths.